### PR TITLE
ref(api)/rename-login-to-claim

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -10,12 +10,12 @@ import {
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
-import { LoginDto } from './dto/login.dto';
 import { VerifyDto } from './dto/verify.dto';
 import { Login } from './interfaces/login.interface';
 import { Verify } from './interfaces/verify.interface';
 import { ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { ClaimDto } from './dto/claim.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -28,9 +28,9 @@ export class AuthController {
       'Generates a nonce for the given public key to proceed with the login flow.',
   })
   @HttpCode(HttpStatus.CREATED)
-  @Post('login')
-  async login(@Body(new ValidationPipe()) dto: LoginDto): Promise<Login> {
-    return this.authService.login(dto);
+  @Post('claim')
+  async claim(@Body(new ValidationPipe()) dto: ClaimDto): Promise<Login> {
+    return this.authService.claim(dto);
   }
 
   @ApiResponse({

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AccountService } from 'src/account/account.service';
-import { LoginDto } from './dto/login.dto';
 import { VerifyDto } from './dto/verify.dto';
 import { Verify } from './interfaces/verify.interface';
 import { Login } from './interfaces/login.interface';
+import { ClaimDto } from './dto/claim.dto';
 
 @Injectable()
 export class AuthService {
@@ -40,7 +40,7 @@ export class AuthService {
     };
   }
 
-  async login(dto: LoginDto): Promise<Login> {
+  async claim(dto: ClaimDto): Promise<Login> {
     const { publicKey, nonce } =
       await this.accountService.generateNonceForPublicKey({
         publicKey: dto.publicKey,

--- a/apps/api/src/auth/dto/claim.dto.ts
+++ b/apps/api/src/auth/dto/claim.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class LoginDto {
+export class ClaimDto {
   @ApiProperty({
     description: 'Public key of the account',
     type: String,


### PR DESCRIPTION
- Changed the endpoint from `/login` to `/claim`.
- Updated the method name from login to claim in AuthController.
- Refactored AuthService to implement claim logic.
- Renamed LoginDto to ClaimDto to better reflect functionality.